### PR TITLE
Fix default and preview option handling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Readability Redux",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "Readability for Chrome. Now fully customizable!",
     "background_page": "redux/background.html",
     "browser_action": { "default_icon": "icon.png" },

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Readability Redux",
-    "version": "1.3",
+    "version": "1.3.1",
     "description": "Readability for Chrome. Now fully customizable!",
     "background_page": "redux/background.html",
     "browser_action": { "default_icon": "icon.png" },

--- a/readability/readability.css
+++ b/readability/readability.css
@@ -85,3 +85,11 @@ a.rdbTK-powered span{display:inline-block;height:22px;margin-left:2px;background
 #kindle-container,#email-container{position:fixed;top:60px;left:50%;width:500px;height:490px;border:solid 3px #666;background-color:#fff;z-index:100!important;overflow:hidden;margin:0 0 0 -240px;padding:0;}
 /* Override html styling attributes */
 table,tr,td{background-color:transparent!important;}
+
+/* We know we installed readability; hide it from the article */
+#readability-logo, #arc90-logo, #readability-url,
+	#rdb-footer-right a.footer-twitterLink {
+  display: none;
+}
+
+

--- a/redux/background.js
+++ b/redux/background.js
@@ -3,7 +3,7 @@ function createJavascript(settings)
 {
     if(settings['remote']) 
     {
-        console.log('Using remote Readability.');
+        //console.log('Using remote Readability.');
 
         js_url = "http://lab.arc90.com/experiments/readability/js/readability.js?x="+(Math.random());
         css_url = "http://lab.arc90.com/experiments/readability/css/readability.css";
@@ -12,11 +12,11 @@ function createJavascript(settings)
     {
       if(settings.enable_experimental)
       {
-          console.log('Using local, experimental Readability.');
+          //console.log('Using local, experimental Readability.');
           var js_url = chrome.extension.getURL('readability/readability-x.js');
       } else
       {
-          console.log('Using local Readability.');
+          //console.log('Using local Readability.');
           var js_url = chrome.extension.getURL('readability/readability.js');
       }
 
@@ -32,7 +32,7 @@ function createJavascript(settings)
 function render(tab_id)
 {
     var settings = getSettings();
-    console.log(settings);
+    //console.log(settings);
 
     chrome.tabs.sendRequest(tab_id, {'type': 'render'});
 }
@@ -101,7 +101,7 @@ function setSettings(settings)
     if(_.include(_.keys(settings), 'keys'))
         settings['keys'] = JSON.stringify(settings['keys']);
 
-    console.log('setSettings', settings);
+    //console.log('setSettings', settings);
 
     _.extend(localStorage, settings);
 

--- a/redux/background.js
+++ b/redux/background.js
@@ -1,3 +1,6 @@
+/* vim:noet:ts=4:sw=4
+ */
+
 var default_settings = {
 	style: 'style-newspaper',
 	size: 'size-large',
@@ -14,31 +17,31 @@ function createJavascript(settings)
 {
 	var js_url, css_url, print_url;
 
-    if (settings.remote && !settings.enable_experimental) {
+	if (settings.remote && !settings.enable_experimental) {
 		var arc90 = "http://lab.arc90.com/experiments/readability/";
-        js_url = arc90 + "js/readability.js?x="+(Math.random());
-        css_url = arc90 + "/css/readability.css";
-        print_url = arc90 + "/css/readability-print.css";
-    } else {
-      if (settings.enable_experimental)
-      {
-          js_url = chrome.extension.getURL('readability/readability-x.js');
-      } else {
-          js_url = chrome.extension.getURL('readability/readability.js');
-      }
+		js_url = arc90 + "js/readability.js?x="+(Math.random());
+		css_url = arc90 + "/css/readability.css";
+		print_url = arc90 + "/css/readability-print.css";
+	} else {
+		if (settings.enable_experimental)
+		{
+			js_url = chrome.extension.getURL('readability/readability-x.js');
+		} else {
+			js_url = chrome.extension.getURL('readability/readability.js');
+		}
 
-      css_url = chrome.extension.getURL('readability/readability.css');
-      print_url = chrome.extension.getURL('readability/readability-print.css');
-    }
+		css_url = chrome.extension.getURL('readability/readability.css');
+		print_url = chrome.extension.getURL('readability/readability-print.css');
+	}
 
-    var code = "(function(){readConvertLinksToFootnotes=" + settings['enable_footnotes'] + ";readStyle='" + settings['style'] + "';readSize='" + settings['size'] + "';readMargin='" + settings['margin'] + "';_readability_script=document.createElement('SCRIPT');_readability_script.type='text/javascript';_readability_script.src='" + js_url + "';document.getElementsByTagName('head')[0].appendChild(_readability_script);_readability_css=document.createElement('LINK');_readability_css.rel='stylesheet';_readability_css.href='" + css_url + "';_readability_css.type='text/css';_readability_css.media='screen';document.getElementsByTagName('head')[0].appendChild(_readability_css);_readability_print_css=document.createElement('LINK');_readability_print_css.rel='stylesheet';_readability_print_css.href='" + print_url + "';_readability_print_css.media='print';_readability_print_css.type='text/css';document.getElementsByTagName('head')[0].appendChild(_readability_print_css);})();";
+	var code = "(function(){readConvertLinksToFootnotes=" + settings['enable_footnotes'] + ";readStyle='" + settings['style'] + "';readSize='" + settings['size'] + "';readMargin='" + settings['margin'] + "';_readability_script=document.createElement('SCRIPT');_readability_script.type='text/javascript';_readability_script.src='" + js_url + "';document.getElementsByTagName('head')[0].appendChild(_readability_script);_readability_css=document.createElement('LINK');_readability_css.rel='stylesheet';_readability_css.href='" + css_url + "';_readability_css.type='text/css';_readability_css.media='screen';document.getElementsByTagName('head')[0].appendChild(_readability_css);_readability_print_css=document.createElement('LINK');_readability_print_css.rel='stylesheet';_readability_print_css.href='" + print_url + "';_readability_print_css.media='print';_readability_print_css.type='text/css';document.getElementsByTagName('head')[0].appendChild(_readability_print_css);})();";
 
-    return code;
+	return code;
 }
 
 function render(tab_id)
 {
-    chrome.tabs.sendRequest(tab_id, {'type': 'render'});
+	chrome.tabs.sendRequest(tab_id, {'type': 'render'});
 }
 
 function getSettings()
@@ -51,7 +54,7 @@ function getSettings()
 		}
 	}
 
-    return settings;
+	return settings;
 }
 
 function setSettings(settings)
@@ -69,40 +72,40 @@ function setSettings(settings)
 	}
 //	console.log('Settings now: ' + JSON.stringify(localStorage));
 
-    chrome.windows.getAll({'populate': true}, function(windows)
-    {
-        _.each(windows, function(window)
-        {
-            _.each(window.tabs, function(tab)
-            {
-                chrome.tabs.sendRequest(tab.id, {'type': 'newSettings', 'settings': getSettings()});
-            });
-        });
-    });
+	chrome.windows.getAll({'populate': true}, function(windows)
+	{
+		_.each(windows, function(window)
+		{
+			_.each(window.tabs, function(tab)
+			{
+				chrome.tabs.sendRequest(tab.id, {'type': 'newSettings', 'settings': getSettings()});
+			});
+		});
+	});
 }
 
 function requestHandler(data, sender, callback)
 {
 	var result = undefined;
 
-    if (data['type'] == 'javascript') {
-        if (_.include(_.keys(data), 'settings'))
-            result = createJavascript(data['settings']);
-        else
-            result = createJavascript(getSettings());
-    }
+	if (data['type'] == 'javascript') {
+		if (_.include(_.keys(data), 'settings'))
+			result = createJavascript(data['settings']);
+		else
+			result = createJavascript(getSettings());
+	}
 
-    if (data['type'] == 'setSettings') {
-        setSettings(data['settings']);
-    }
+	if (data['type'] == 'setSettings') {
+		setSettings(data['settings']);
+	}
 
-    if (data['type'] == 'getSettings') {
-        result = getSettings();
-    }
+	if (data['type'] == 'getSettings') {
+		result = getSettings();
+	}
 
-    if (data['type'] == 'render') {
-        render(data['tab_id']);
-    }
+	if (data['type'] == 'render') {
+		render(data['tab_id']);
+	}
 
 	callback(result);
 }
@@ -112,6 +115,6 @@ chrome.extension.onRequestExternal.addListener(requestHandler);
 
 chrome.browserAction.onClicked.addListener(function(tab)
 {
-    render(tab.id);
+	render(tab.id);
 });
 

--- a/redux/contentscript.js
+++ b/redux/contentscript.js
@@ -85,7 +85,7 @@ var listener = {
         this.enabled = settings["enable_keys"];
         this.goal = settings["keys"];
         this.current_state = [];
-        console.log(settings);
+        //console.log(settings);
     }
 
 };

--- a/redux/contentscript.js
+++ b/redux/contentscript.js
@@ -92,13 +92,19 @@ var listener = {
 
 function render()
 {
-    chrome.extension.sendRequest({'type': 'javascript'}, function(response)
-    {
-        var script = document.createElement('script');
-        script.appendChild(document.createTextNode(response));
-        console.log(document.getElementsByTagName('head'));
-        document.getElementsByTagName('head')[0].appendChild(script);
-    });
+	var head = document.getElementsByTagName('head')[0];
+	if (head.readability_redux) {
+		window.location.reload();
+	} else {
+		chrome.extension.sendRequest({'type': 'javascript'}, 
+			function(response) {
+				var script = document.createElement('script');
+				script.appendChild(document.createTextNode(response));
+				head.readability_redux = true;
+				head.appendChild(script);
+			}
+		);
+	}
 }
 
 chrome.extension.onRequest.addListener(function(data, sender, callback)

--- a/redux/example.html
+++ b/redux/example.html
@@ -170,7 +170,7 @@ See <A href="http://wikimediafoundation.org/wiki/Terms_of_Use">Terms of Use</A> 
 <script type="text/javascript">
 function inject(js)
 {
-    document.location = 'javascript:' + js;
+	eval(js);
 }
 
 parent.settings.hello_from_child(window);

--- a/redux/options.html
+++ b/redux/options.html
@@ -45,8 +45,8 @@
 </p>
 
 <p>
-<input type="checkbox" id="enable_links" />
-<label for="enable_links">Convert links to footnotes(<a href="http://blog.arc90.com/2010/06/03/readability-updated-an-end-to-the-yank-of-the-hyperlink/">more</a>).</label>
+<input type="checkbox" id="enable_footnotes" />
+<label for="enable_footnotes">Convert links to footnotes (<a target="_new" href="http://blog.arc90.com/2010/06/03/readability-updated-an-end-to-the-yank-of-the-hyperlink/">more</a>).</label>
 </p>
 
 <p>
@@ -57,8 +57,14 @@
 
 <p>
 <input type="checkbox" id="enable_experimental" name="enable_experimental" />
-<label for="enable_experimental">Apply Readability only to selected fragment (experimental).</label>
+<label for="enable_experimental">Apply Readability only to selected fragment (experimental; forces use of bundled Readability).</label>
 </p>
+
+<p>
+<input type="checkbox" id="remote" name="remote" />
+<label for="remote">Use remote Readability hosted by arc90 (requires additional network traffic; otherwise, use bundled version 1.7.1)</label>
+</p>
+
 
 <p>
 <button id="save">Save</button>

--- a/redux/options.js
+++ b/redux/options.js
@@ -3,8 +3,10 @@ var settings = {
 
     init: function()
     {
-        $('select').change(_.bind(function() { this.preview(); this.markDirty(); }, this)); 
-        $('input').change(_.bind(this.markDirty, this)); 
+        $('select, input').change(_.bind(function() {
+			this.preview();
+			this.markDirty();
+		}, this));
 
         $('#cancel').click(_.bind(this.load, this));
         $('#save').click(_.bind(this.save, this));
@@ -41,14 +43,15 @@ var settings = {
             style: this.getSelect('r_style'),
             size: this.getSelect('r_size'),
             margin: this.getSelect('r_margin'),
-            enable_links: $('#enable_links').attr('checked'),
+            enable_footnotes: $('#enable_footnotes').attr('checked'),
             enable_experimental: $('#enable_experimental').attr('checked'),
             enable_keys: $('#enable_keys').attr('checked'),
+            remote: $('#remote').attr('checked'),
             keys: keybox.keys
         };
 
         //console.log(settings);
-        
+
         chrome.extension.sendRequest(
             {'type': 'setSettings', 'settings': settings},
             _.bind(this.markClean, this));
@@ -61,15 +64,18 @@ var settings = {
             this.setSelect('r_style', settings['style']);
             this.setSelect('r_size', settings['size']);
             this.setSelect('r_margin', settings['margin']);
-            $('#enable_links').attr('checked', settings['enable_links']);
-            
+            $('#enable_footnotes').attr('checked', settings['enable_footnotes']);
+
             keybox.keys = settings['keys'];
             if(settings['enable_keys'])
                 keybox.enable();
             else
                 keybox.disable();
 
-              $('#enable_experimental').attr('checked', settings['enable_experimental']);
+			$('#enable_experimental').attr('checked',
+				settings['enable_experimental']);
+
+			$('#remote').attr('checked', settings['remote']);
 
             keybox.update();
             this.preview()
@@ -77,8 +83,9 @@ var settings = {
         }, this));
     },
 
-    /* This is a bit wicked, but doing plain simple 
+    /* This is a bit wicked, but doing plain simple
      * location = 'javascript:...' resulted in blank iframe.
+     * (this is used in redux/example.html for the preview)
      */
     hello_from_child: function(preview_window)
     {
@@ -93,7 +100,9 @@ var settings = {
         var settings = {
             style: this.getSelect('r_style'),
             size: this.getSelect('r_size'),
-            margin: this.getSelect('r_margin')
+            margin: this.getSelect('r_margin'),
+            enable_footnotes: $('#enable_footnotes').attr('checked'),
+            remote: $('#remote').attr('checked')
         };
 
         chrome.extension.sendRequest({'type': 'javascript', 'settings': settings}, _.bind(function(js)
@@ -102,7 +111,6 @@ var settings = {
             {
                 this.preview_window.inject(js);
             }
-            else console.log('ZOMG! Preview window IS NULL!');
         }, this));
     }
 };

--- a/redux/options.js
+++ b/redux/options.js
@@ -1,245 +1,247 @@
+/* vim:noet:ts=4:sw=4
+ */
 
 var settings = {
 
-    init: function()
-    {
-        $('select, input').change(_.bind(function() {
+	init: function() {
+		$('select, input').change(_.bind(function() {
 			this.preview();
 			this.markDirty();
 		}, this));
 
-        $('#cancel').click(_.bind(this.load, this));
-        $('#save').click(_.bind(this.save, this));
+		$('#cancel').click(_.bind(this.load, this));
+		$('#save').click(_.bind(this.save, this));
 
-        this.load();
-    },
+		this.load();
+	},
 
-    getSelect: function(name)
-    {
-        return $('#' + name).val();
-    },
+	getSelect: function(name)
+	{
+		return $('#' + name).val();
+	},
 
-    setSelect: function(name, value)
-    {
-        if($('#' + name + ' option[value=' + value + ']')
-           .attr('selected', 'selected')
-           .val() === undefined)
-           $('#' + name + ' option:first-child').attr('selected', 'selected');
-    },
+	setSelect: function(name, value)
+	{
+		if ($('#' + name + ' option[value=' + value + ']')
+				.attr('selected', 'selected')
+				.val() === undefined) {
+			$('#' + name + ' option:first-child').attr('selected', 'selected');
+		}
+	},
 
-    markDirty: function()
-    {
-        $('#save').attr('disabled', '');
-    },
+	markDirty: function()
+	{
+		$('#save').attr('disabled', '');
+	},
 
-    markClean: function()
-    {
-        $('#save').attr('disabled', 'disabled');
-    },
+	markClean: function()
+	{
+		$('#save').attr('disabled', 'disabled');
+	},
 
-    save: function()
-    {
-        var settings = {
-            style: this.getSelect('r_style'),
-            size: this.getSelect('r_size'),
-            margin: this.getSelect('r_margin'),
-            enable_footnotes: $('#enable_footnotes').attr('checked'),
-            enable_experimental: $('#enable_experimental').attr('checked'),
-            enable_keys: $('#enable_keys').attr('checked'),
-            remote: $('#remote').attr('checked'),
-            keys: keybox.keys
-        };
+	save: function()
+	{
+		var settings = {
+			style: this.getSelect('r_style'),
+			size: this.getSelect('r_size'),
+			margin: this.getSelect('r_margin'),
+			enable_footnotes: $('#enable_footnotes').attr('checked'),
+			enable_experimental: $('#enable_experimental').attr('checked'),
+			enable_keys: $('#enable_keys').attr('checked'),
+			remote: $('#remote').attr('checked'),
+			keys: keybox.keys
+		};
 
-        //console.log(settings);
+		//console.log(settings);
 
-        chrome.extension.sendRequest(
-            {'type': 'setSettings', 'settings': settings},
-            _.bind(this.markClean, this));
-    },
+		chrome.extension.sendRequest(
+			{'type': 'setSettings', 'settings': settings},
+			_.bind(this.markClean, this));
+	},
 
-    load: function()
-    {
-        chrome.extension.sendRequest({'type': 'getSettings'}, _.bind(function(settings)
-        {
-            this.setSelect('r_style', settings['style']);
-            this.setSelect('r_size', settings['size']);
-            this.setSelect('r_margin', settings['margin']);
-            $('#enable_footnotes').attr('checked', settings['enable_footnotes']);
+	load: function()
+	{
+		chrome.extension.sendRequest({'type': 'getSettings'}, _.bind(function(settings)
+		{
+			this.setSelect('r_style', settings['style']);
+			this.setSelect('r_size', settings['size']);
+			this.setSelect('r_margin', settings['margin']);
+			$('#enable_footnotes').attr('checked', settings['enable_footnotes']);
 
-            keybox.keys = settings['keys'];
-            if(settings['enable_keys'])
-                keybox.enable();
-            else
-                keybox.disable();
+			keybox.keys = settings['keys'];
+			if(settings['enable_keys'])
+				keybox.enable();
+			else
+				keybox.disable();
 
 			$('#enable_experimental').attr('checked',
 				settings['enable_experimental']);
 
 			$('#remote').attr('checked', settings['remote']);
 
-            keybox.update();
-            this.preview()
-            this.markClean();
-        }, this));
-    },
+			keybox.update();
+			this.preview()
+			this.markClean();
+		}, this));
+	},
 
-    /* This is a bit wicked, but doing plain simple
-     * location = 'javascript:...' resulted in blank iframe.
-     * (this is used in redux/example.html for the preview)
-     */
-    hello_from_child: function(preview_window)
-    {
-        this.preview_window = preview_window;
-        this.preview();
-    },
+	/* This is a bit wicked, but doing plain simple
+		* location = 'javascript:...' resulted in blank iframe.
+		* (this is used in redux/example.html for the preview)
+		*/
+	hello_from_child: function(preview_window)
+	{
+		this.preview_window = preview_window;
+		this.preview();
+	},
 
-    preview_window: null,
+	preview_window: null,
 
-    preview: function()
-    {
-        var settings = {
-            style: this.getSelect('r_style'),
-            size: this.getSelect('r_size'),
-            margin: this.getSelect('r_margin'),
-            enable_footnotes: $('#enable_footnotes').attr('checked'),
-            remote: $('#remote').attr('checked')
-        };
+	preview: function()
+	{
+		var settings = {
+			style: this.getSelect('r_style'),
+			size: this.getSelect('r_size'),
+			margin: this.getSelect('r_margin'),
+			enable_footnotes: $('#enable_footnotes').attr('checked'),
+			remote: $('#remote').attr('checked')
+		};
 
-        chrome.extension.sendRequest({'type': 'javascript', 'settings': settings}, _.bind(function(js)
-        {
-            if(this.preview_window !== null)
-            {
-                this.preview_window.inject(js);
-            }
-        }, this));
-    }
+		chrome.extension.sendRequest({'type': 'javascript', 'settings': settings}, _.bind(function(js)
+		{
+			if(this.preview_window !== null)
+			{
+				this.preview_window.inject(js);
+			}
+		}, this));
+	}
 };
 
 
 var keybox = {
-    pressed: 0,
-    keys: [],
-    enabled: false,
+	pressed: 0,
+	keys: [],
+	enabled: false,
 
-    init: function()
-    {
-        $('#keys').keydown(_.bind(this.keydown, this));
-        $('#keys').keyup(_.bind(this.keyup, this));
-        $('#keys').focus(_.bind(this.focus, this));
-        $('#keys').blur(_.bind(this.blur, this));
-        $('#enable_keys').change(_.bind(this.checkbox, this));
-    },
+	init: function()
+	{
+		$('#keys').keydown(_.bind(this.keydown, this));
+		$('#keys').keyup(_.bind(this.keyup, this));
+		$('#keys').focus(_.bind(this.focus, this));
+		$('#keys').blur(_.bind(this.blur, this));
+		$('#enable_keys').change(_.bind(this.checkbox, this));
+	},
 
-    enable: function()
-    {
-        $('#enable_keys').attr('checked', 'checked');
-        $('#keys').css('background-color', '');
-        $('#keys').css('color', '');
-        this.enabled = 1;
-    },
+	enable: function()
+	{
+		$('#enable_keys').attr('checked', 'checked');
+		$('#keys').css('background-color', '');
+		$('#keys').css('color', '');
+		this.enabled = 1;
+	},
 
-    disable: function()
-    {
-        $('#enable_keys').attr('checked', '');
-        $('#keys').css('background-color', 'silver');
-        $('#keys').css('color', 'gray');
-        this.enabled = 0;
-    },
+	disable: function()
+	{
+		$('#enable_keys').attr('checked', '');
+		$('#keys').css('background-color', 'silver');
+		$('#keys').css('color', 'gray');
+		this.enabled = 0;
+	},
 
-    checkbox: function()
-    {
-        if($('#enable_keys').attr('checked'))
-            this.enable();
-        else
-            this.disable();
-    },
+	checkbox: function()
+	{
+		if($('#enable_keys').attr('checked'))
+			this.enable();
+		else
+			this.disable();
+	},
 
-    // It sometimes fails, like when Ctrl+Shift+U, U has a strange key code 229. Dunno why.
-    keydown: function(e)
-    {
-        if(!this.enabled)
-            return;
+	// It sometimes fails, like when Ctrl+Shift+U, U has a strange key code 229. Dunno why.
+	keydown: function(e)
+	{
+		if(!this.enabled)
+			return;
 
-        if(!((e.which >= 65 && e.which <= 90) || e.which == 16 || e.which == 17 || e.which == 18))
-            return false;
+		if(!((e.which >= 65 && e.which <= 90) || e.which == 16 || e.which == 17 || e.which == 18))
+			return false;
 
-        if(this.pressed == 0)
-            this.keys = [];
+		if(this.pressed == 0)
+			this.keys = [];
 
-        if(_.include(this.keys, e.which)) // Degenerate situation
-        {
-            this.keys = [];
-            this.pressed = 0;
-        }
+		if(_.include(this.keys, e.which)) // Degenerate situation
+		{
+			this.keys = [];
+			this.pressed = 0;
+		}
 
-        this.keys.push(e.which);
-        this.pressed++;
+		this.keys.push(e.which);
+		this.pressed++;
 
-        settings.markDirty();
-        this.update();
-    },
+		settings.markDirty();
+		this.update();
+	},
 
-    keyup: function(e)
-    {
-        if(!this.enabled)
-            return;
+	keyup: function(e)
+	{
+		if(!this.enabled)
+			return;
 
-        if(!((e.which >= 65 && e.which <= 90) || e.which == 16 || e.which == 17 || e.which == 18))
-            return false;
+		if(!((e.which >= 65 && e.which <= 90) || e.which == 16 || e.which == 17 || e.which == 18))
+			return false;
 
-        this.pressed--;
+		this.pressed--;
 
-        this.update();
-    },
+		this.update();
+	},
 
-    update: function()
-    {
-        var value = [];
-        this.keys.sort();
+	update: function()
+	{
+		var value = [];
+		this.keys.sort();
 
-        for(var i = 0; i < this.keys.length; i++)
-        {
-            var key = this.keys[i];
-            if(key >= 65 && key <= 90)
-                value.push(String.fromCharCode(key));
+		for(var i = 0; i < this.keys.length; i++)
+		{
+			var key = this.keys[i];
+			if(key >= 65 && key <= 90)
+				value.push(String.fromCharCode(key));
 
-            if(key == 16)
-                value.push("Shift");
+			if(key == 16)
+				value.push("Shift");
 
-            if(key == 17)
-                value.push("Ctrl");
+			if(key == 17)
+				value.push("Ctrl");
 
-            if(key == 18)
-                value.push("Alt");
-        }
+			if(key == 18)
+				value.push("Alt");
+		}
 
-        $("#keys").attr('value', value.join(' + '));
-    },
+		$("#keys").attr('value', value.join(' + '));
+	},
 
-    focus: function()
-    {
-        if(!this.enabled)
-            return;
+	focus: function()
+	{
+		if(!this.enabled)
+			return;
 
-        $('#keys').css('background-color', '#ebeff9');
-    },
+		$('#keys').css('background-color', '#ebeff9');
+	},
 
-    blur: function()
-    {
-        if(!this.enabled)
-            return;
+	blur: function()
+	{
+		if(!this.enabled)
+			return;
 
-        $('#keys').css('background-color', '');
-        $('#keys').css('color', '');
-    }
+		$('#keys').css('background-color', '');
+		$('#keys').css('color', '');
+	}
 };
 
 $(document).ready(function()
 {
-    $('#example iframe').ready(function()
-    {
-        settings.init();
-        keybox.init();
-    });
+	$('#example iframe').ready(function()
+	{
+		settings.init();
+		keybox.init();
+	});
 });
 

--- a/redux/options.js
+++ b/redux/options.js
@@ -47,7 +47,7 @@ var settings = {
             keys: keybox.keys
         };
 
-        console.log(settings);
+        //console.log(settings);
         
         chrome.extension.sendRequest(
             {'type': 'setSettings', 'settings': settings},


### PR DESCRIPTION
In addition to the earlier pull request that makes the toolbar button toggle readability mode, this set of changes:
- Fixes the default values of options when the extension is first loaded
- Applies the footnote option to the preview in the options screen
- Exposes the option to use the remote hosted arc90 readability javascript vs. the local copy. previously, only the remote could be used, and this prevented the experimental selection feature from working

I've also modified the local readability.css to hide the readability and arc90 logos, as these seem to counter the intent of the extension, which is to reduce visual noise and clutter.
